### PR TITLE
Move references from csproj to Directory.Build.targets

### DIFF
--- a/content/LCBepinExTemplateSimple/Directory.Build.targets
+++ b/content/LCBepinExTemplateSimple/Directory.Build.targets
@@ -1,11 +1,24 @@
 <Project>
 
-  <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
+  <Import Project="$(SolutionRoot)Config.Build.user.props"
+    Condition="Exists('$(SolutionRoot)Config.Build.user.props')" />
+
+  <ItemGroup>
     <PackageReference
-      Include="Microsoft.NETFramework.ReferenceAssemblies"
-      PrivateAssets="all"
-      Version="1.0.2"
-    />
+      Include="BepInEx.Analyzers"
+      Version="1.*"
+      PrivateAssets="all" />
+
+    <PackageReference
+      Include="BepInEx.Core"
+      Version="5.4.21" />
+
+    <!-- Keep this up to date with the newest GameLibs as the game updates. -->
+    <PackageReference
+      Include="LethalCompany.GameLibs.Steam"
+      Version="69.0.1-ngd.0"
+      Private="False"
+      PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="AddGeneratedFile" BeforeTargets="BeforeCompile;CoreCompile"

--- a/content/LCBepinExTemplateSimple/src/BepInExModTemplate/BepInExModTemplate.csproj
+++ b/content/LCBepinExTemplateSimple/src/BepInExModTemplate/BepInExModTemplate.csproj
@@ -9,26 +9,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference
-      Include="BepInEx.Analyzers"
-      PrivateAssets="all"
-      Version="1.*" />
-
-    <PackageReference
-      Include="BepInEx.Core"
-      Version="5.4.*" />
-
-    <!-- Keep this up to date with the newest gamelibs as the game updates-->
-    <PackageReference
-      Include="LethalCompany.GameLibs.Steam"
-      Version="69.0.1-ngd.0"
-      Private="False"
-      Publicize="True"
-    />
-  </ItemGroup>
-
-  <!-- 
+  <!--
   How to include thunderstore mods as dependencies via nuget
 
   I have already added the windows10ce nuget feed to this project
@@ -44,7 +25,5 @@
   methods will be available at compile time for your code. You'll still
   need to add it as a dependency in your manifest.json, of course
   -->
-
-  <Import Project="$(SolutionRoot)Config.Build.user.props" />
 
 </Project>


### PR DESCRIPTION
Reasoning:
These are very general references, and it's likely that all projects will be using them. It will also be easier to update the GameLibs package version in only one place.

Other changes:
- LethalCompany.GameLibs.Steam:
  - marked as PrivateAssets="all" so users of potential NuGet package don't need to also reference it
  - removed Publicize="True" since it's already publicized
- Import Project Config.Build.user.props:
  - moved from csproj to Directory.Build.props
  - only import if the file exists
  
Also removes:
```xml
<ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
  <PackageReference
    Include="Microsoft.NETFramework.ReferenceAssemblies"
    PrivateAssets="all"
    Version="1.0.2"
  />
</ItemGroup>
```
because it doesn't apply to netstandard, and we kinda already rely on netstandard in our references anyways.